### PR TITLE
Check for `model` key before expecting it

### DIFF
--- a/src/app/Library/CrudPanel/Traits/FakeFields.php
+++ b/src/app/Library/CrudPanel/Traits/FakeFields.php
@@ -39,7 +39,7 @@ trait FakeFields
                 $isFakeField = $field['fake'] ?? false;
 
                 // field is represented by the subfields
-                if (isset($field['subfields']) && $field['model'] === get_class($model)) {
+                if (isset($field['subfields']) && isset($field['model']) && $field['model'] === get_class($model)) {
                     foreach ($field['subfields'] as $subfield) {
                         $subfieldName = Str::afterLast($subfield['name'], '.');
                         $isSubfieldFake = $subfield['fake'] ?? false;


### PR DESCRIPTION
Solves issues where the field may not have a `model` key, such as in `checklist_dependency` fields. This fixes the issue found in PermissionManager here - https://github.com/Laravel-Backpack/PermissionManager/issues/291

## WHY

### BEFORE - What was wrong? What was happening before this PR?

??

### AFTER - What is happening after this PR?

??


## HOW

### How did you achieve that, in technical terms?

??



### Is it a breaking change or non-breaking change?

??


### How can we test the before & after?

??
